### PR TITLE
Ignore extra values for nested configs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = False
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #############################################
 # Tox testsuite for multiple python version #
 #############################################
-FROM advian/tox-base:debian-bookworm as tox
+FROM advian/tox-base:debian-bookworm AS tox
 ARG PYTHON_VERSIONS="3.11"
 ARG POETRY_VERSION="1.5.1"
 RUN export RESOLVED_VERSIONS=`pyenv_resolve $PYTHON_VERSIONS` \
@@ -20,7 +20,7 @@ RUN export RESOLVED_VERSIONS=`pyenv_resolve $PYTHON_VERSIONS` \
 ######################
 # Base builder image #
 ######################
-FROM python:3.11-bookworm as builder_base
+FROM python:3.11-bookworm AS builder_base
 
 ENV \
   # locale
@@ -77,7 +77,7 @@ RUN --mount=type=ssh pip3 install wheel virtualenv \
 ####################################
 # Base stage for production builds #
 ####################################
-FROM builder_base as production_build
+FROM builder_base AS production_build
 # Copy entrypoint script
 COPY ./docker/entrypoint.sh /docker-entrypoint.sh
 # Only files needed by production setup
@@ -94,7 +94,7 @@ RUN --mount=type=ssh source /.venv/bin/activate \
 #########################
 # Main production build #
 #########################
-FROM python:3.11-slim-bookworm as production
+FROM python:3.11-slim-bookworm AS production
 COPY --from=production_build /tmp/wheelhouse /tmp/wheelhouse
 COPY --from=production_build /docker-entrypoint.sh /docker-entrypoint.sh
 WORKDIR /app
@@ -120,7 +120,7 @@ ENTRYPOINT ["/usr/bin/tini", "--", "/docker-entrypoint.sh"]
 #####################################
 # Base stage for development builds #
 #####################################
-FROM builder_base as devel_build
+FROM builder_base AS devel_build
 # Install deps
 WORKDIR /pysetup
 RUN --mount=type=ssh source /.venv/bin/activate \
@@ -131,7 +131,7 @@ RUN --mount=type=ssh source /.venv/bin/activate \
 #0############
 # Run tests #
 #############
-FROM devel_build as test
+FROM devel_build AS test
 COPY . /app
 WORKDIR /app
 ENTRYPOINT ["/usr/bin/tini", "--", "docker/entrypoint-test.sh"]
@@ -145,7 +145,7 @@ RUN --mount=type=ssh source /.venv/bin/activate \
 ###########
 # Hacking #
 ###########
-FROM devel_build as devel_shell
+FROM devel_build AS devel_shell
 # Copy everything to the image
 COPY . /app
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miniwerk"
-version = "1.3.0"
+version = "1.3.1"
 description = "Minimal KRAFTWERK amulation to be able to run a RASENMAEHER+products deployment on any VM"
 authors = ["Eero af Heurlin <eero.afheurlin@iki.fi>"]
 homepage = "https://github.com/pvarki/python-rasenmaeher-miniwerk/"

--- a/src/miniwerk/__init__.py
+++ b/src/miniwerk/__init__.py
@@ -1,2 +1,2 @@
 """ Minimal KRAFTWERK amulation to be able to run a RASENMAEHER+products deployment on any VM """
-__version__ = "1.3.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.3.1"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/miniwerk/config.py
+++ b/src/miniwerk/config.py
@@ -23,6 +23,8 @@ class ProductSettings(BaseSettings):
     api_base: str = Field(description="base url for the API", default="/")
     user_base: str = Field(description="base url for normal users", default="/")
 
+    model_config = SettingsConfigDict(extra="ignore")
+
 
 class MWConfig(BaseSettings):
     """Config for MiniWerk"""

--- a/tests/test_miniwerk.py
+++ b/tests/test_miniwerk.py
@@ -4,4 +4,4 @@ from miniwerk import __version__
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.3.0"
+    assert __version__ == "1.3.1"


### PR DESCRIPTION
So if someone is mixing new ENV configs with old miniwerk things do not immediately explode.

They *will* probably get weird later though.