### PR TITLE
[Do not merge - demo tunk for fun] feat: register takanalyzer as a miniwerk product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE settings
 .idea
+.helpstuff/
 
 # testing artefacts
 pytest*.xml

--- a/src/miniwerk/config.py
+++ b/src/miniwerk/config.py
@@ -39,7 +39,7 @@ class MWConfig(BaseSettings):
     le_test: bool = Field(default=True, description="Use LE staging/test env")
     subdomains: str = Field(default="mtls", description="Comma separated list of extra subdomains to get certs for")
     products: str = Field(
-        default="fake,tak,bl,mtx,matrix",
+        default="fake,tak,bl,mtx,matrix,takanalyzer",
         description="Comma separated list of products to create manifests and get subdomains for",
     )
     fake: ProductSettings = Field(
@@ -64,6 +64,12 @@ class MWConfig(BaseSettings):
     matrix: ProductSettings = Field(
         description="Setting for Matrix integration API",
         default_factory=lambda: ProductSettings(api_host="matrix", user_host="matrix", api_port=4626, user_port=4626),
+    )
+    takanalyzer: ProductSettings = Field(
+        description="Settings for the TAK-analyzer integration API",
+        default_factory=lambda: ProductSettings(
+            api_host="takanalyzer", user_host="takanalyzer", api_port=4626, user_port=4626
+        ),
     )
 
     le_cert_name: str = Field(default="rasenmaeher", description="--cert-name for LE, used to determine directory name")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ def test_defaults() -> None:
     assert cfg.ci is True
     assert cfg.domain == "pytest.pvarki.fi"
     assert cfg.subdomains == "mtls"
-    assert cfg.products == "fake,tak,bl,mtx,matrix"
+    assert cfg.products == "fake,tak,bl,mtx,matrix,takanalyzer"
     assert str(cfg.data_path) != "/data/persistent"
     assert cfg.le_email == "example@example.com"
     LOGGER.debug(f"cfg.fqdns={cfg.fqdns}")
@@ -35,6 +35,8 @@ def test_defaults() -> None:
         "mtx.pytest.pvarki.fi",
         "mtls.matrix.pytest.pvarki.fi",
         "matrix.pytest.pvarki.fi",
+        "mtls.takanalyzer.pytest.pvarki.fi",
+        "takanalyzer.pytest.pvarki.fi",
     }
     assert cfg.keytype is KeyType.ECDSA
 
@@ -67,3 +69,23 @@ def test_kc_in_fqdns() -> None:
     """Test the singleton fetcher"""
     cfg = MWConfig.singleton()
     assert f"kc.{cfg.domain}" in cfg.fqdns
+
+
+def test_takanalyzer_defaults() -> None:
+    """takanalyzer product resolves with the expected hosts/ports by default"""
+    cfg = MWConfig()  # type: ignore[call-arg]
+    assert "takanalyzer" in cfg.products.split(",")
+    assert cfg.takanalyzer.api_host == "takanalyzer"
+    assert cfg.takanalyzer.user_host == "takanalyzer"
+    assert cfg.takanalyzer.api_port == 4626
+    assert cfg.takanalyzer.user_port == 4626
+
+
+def test_takanalyzer_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Platform MW_TAKANALYZER__* env overrides bind to the takanalyzer product settings"""
+    with monkeypatch.context() as mpatch:
+        mpatch.setenv("MW_TAKANALYZER__API_PORT", "443")
+        mpatch.setenv("MW_TAKANALYZER__USER_PORT", "443")
+        cfg = MWConfig()  # type: ignore[call-arg]
+        assert cfg.takanalyzer.api_port == 443
+        assert cfg.takanalyzer.user_port == 443

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -48,3 +48,21 @@ async def test_fakeproduct_manifest() -> None:
     assert claims["csr"]
     assert claims["nonce"]
     assert f"mtls.{config.domain}" in manifest["rasenmaeher"]["mtls"]["base_uri"]
+
+
+@pytest.mark.asyncio
+async def test_takanalyzer_manifest() -> None:
+    """Check takanalyzer gets an identity (CSR JWT) + manifest with takanalyzer hosts"""
+    config = MWConfig.singleton()
+    pth = next(cand for cand in await create_all_product_manifests() if "/takanalyzer/" in str(cand))
+    check_jwt_pubkey(pth)
+    manifest = json.loads(pth.read_text(encoding="utf-8"))
+    LOGGER.debug(f"manifest={manifest}")
+    verifier = await get_verifier()
+    claims = verifier.decode(manifest["rasenmaeher"]["init"]["csr_jwt"])
+    LOGGER.debug(f"claims={claims}")
+    assert claims["csr"]
+    assert claims["sub"] == f"takanalyzer.{config.domain}"
+    assert manifest["product"]["dns"] == f"takanalyzer.{config.domain}"
+    assert f"takanalyzer.{config.domain}" in manifest["product"]["api"]
+    assert f"takanalyzer.{config.domain}" in manifest["product"]["uri"]


### PR DESCRIPTION
Add the takanalyzer product so miniwerk generates its mTLS identity and kraftwerk manifest into the shared-data dir, letting rmapi/rmui render the takAnalyzer Deploy App card.

- config.py: add `takanalyzer` to the `products` default and add the `takanalyzer: ProductSettings` field. The field is load-bearing so pydantic-settings binds the platform's MW_TAKANALYZER__API_PORT / MW_TAKANALYZER__USER_PORT env overrides; without it those vars are silently ignored and a `takanalyzer` entry in MW_PRODUCTS resolves to no settings. Per-product cert/manifest handling is already generic (getattr(config, <product>)), so no other code changes are needed.
- tests: update the defaults/fqdns assertions for the new product and add cases asserting takanalyzer resolves (hosts + MW_TAKANALYZER__* port overrides) and that an identity (CSR JWT, sub=takanalyzer.<domain>) + manifest are generated for it.
- .gitignore: keep the dropped-in .helpstuff/ guidance docs out of the repo.
